### PR TITLE
Add missing deps for testing

### DIFF
--- a/centos7-python-tests/Dockerfile
+++ b/centos7-python-tests/Dockerfile
@@ -3,4 +3,9 @@ RUN yum install python-setuptools pygobject2-devel -y && \
     easy_install pip && \
     pip install mock && \
     pip install pep8 && \
+    pip install pyOpenSSL && \
+    pip install simplejson && \
+    pip install suds && \
+    pip install requests && \
     yum clean all
+


### PR DESCRIPTION
For internal use we need to add multiple dependencies to the python test images